### PR TITLE
Replace training terminal markup

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,35 +1,439 @@
-<!DOCTYPE html>
-<html lang="en-AU">
+<!doctype html>
+<html lang="en-au">
 <head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Echo Platoon Intelligence Network</title>
-  <link rel="stylesheet" href="css/style.css" />
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Share+Tech+Mono&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-bx4V2mJrL1IzBgE4c3OJbGdv8ImZ/Sc7VcRbP5hqjv3Vv4Y20N6l04e6QF6UVx/F4WRzE7vOjIvmhjYQdkT1Fg==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+  <style>
+    :root{
+      --army: #3C441E;           /* Army green */
+      --army-900:#2a3014;
+      --army-700:#323a19;
+      --army-600:#38401c;
+      --sand:#f1f3ea;
+      --ink:#0c0f0a;
+      --grid:#d9e3c4;
+      --accent:#e5b400;         /* gold accent */
+    }
+    *{box-sizing:border-box}
+    html,body{height:100%}
+    body{
+      margin:0;
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", "Courier New", monospace;
+      color:#e7eae3; background:linear-gradient(180deg,var(--army-900),#12150d 40%, #10130b);
+    }
+    header{
+      position:sticky; top:0; z-index:5;
+      background:linear-gradient(180deg,var(--army),var(--army-700));
+      border-bottom:1px solid #2b3115; color:#fff;
+    }
+    .wrap{max-width:1200px;margin:0 auto;padding:14px 18px}
+    .brand{
+      display:flex;align-items:center;gap:12px;font-weight:700;letter-spacing:.03em
+    }
+    .badge{
+      width:42px;height:42px;border-radius:6px;
+      background:radial-gradient(50% 70% at 50% 30%,#5c662f 0%,var(--army-700) 100%);
+      display:grid;place-items:center;border:1px solid #2b3115; box-shadow:inset 0 0 0 2px rgba(255,255,255,.06)
+    }
+    main{max-width:1200px;margin:16px auto;padding:0 18px;display:grid;gap:16px;grid-template-columns:1.2fr .8fr}
+    @media (max-width:980px){ main{grid-template-columns:1fr}}
+    /* Terminal */
+    .term{
+      background: #0b0f08 url('https://224armycadetunit.com/wp-content/uploads/2024/08/bg-topo-map.svg') center/900px auto repeat;
+      border:1px solid #2e3319;border-radius:12px; overflow:hidden;
+      box-shadow:0 10px 30px rgba(0,0,0,.35);
+    }
+    .term-bar{
+      padding:10px 12px; background:linear-gradient(180deg,#18200e,#0f1509);
+      border-bottom:1px solid #2b3115; display:flex;align-items:center;gap:10px
+    }
+    .dot{width:10px;height:10px;border-radius:999px;background:#8a2e2e;box-shadow:0 0 0 2px rgba(0,0,0,.25) inset}
+    .dot.yellow{background:#7a6a25}
+    .dot.green{background:#2f6c33}
+    .term-title{margin-left:6px;font-size:12px;color:#d9e3c4;opacity:.9}
+    .screen{
+      height:520px; overflow:auto; padding:14px 16px;
+      font-size:14px; line-height:1.45; scrollbar-gutter:stable both-edges
+    }
+    .row{white-space:pre-wrap}
+    .prompt{color:#c8ff8c}
+    .host{color:#9cd3ff}
+    .out{color:#e7eae3}
+    .muted{color:#9aa38b}
+    .success{color:#90fca3}
+    .warn{color:#ffd07a}
+    .err{color:#ff9c9c}
+    .inputline{display:flex; gap:8px; align-items:flex-start}
+    .caret{
+      width:8px;height:16px;background:#c8ff8c;animation:blink 1s steps(1) infinite
+    }
+    @keyframes blink{50%{opacity:0}}
+    .cmd{flex:1;background:transparent;border:0;color:#e7eae3;outline:0;font:inherit}
+    .cmd::placeholder{color:#90a07e}
+    /* Side panel */
+    .panel{
+      background:rgba(19,23,12,.6); border:1px solid #2e3319;border-radius:12px; overflow:hidden
+    }
+    .panel h3{margin:0;padding:12px 14px;border-bottom:1px solid #2b3115;background:linear-gradient(180deg,#18200e,#0f1509);font-size:14px;color:#d9e3c4}
+    .panel .body{padding:14px}
+    .status{
+      display:grid;grid-template-columns:1fr 1fr;gap:8px;font-size:13px
+    }
+    .k{color:#9aa38b}
+    .v{color:#e7eae3;font-weight:600}
+    .chips{display:flex;gap:6px;flex-wrap:wrap;margin-top:10px}
+    .chip{padding:4px 8px;border:1px solid #2e3319;border-radius:999px;background:#12170c;color:#cfd7bf;font-size:12px}
+    .btn{
+      display:inline-flex;align-items:center;gap:8px; padding:8px 10px;
+      background:linear-gradient(180deg,#1a210f,#13190c);
+      border:1px solid #2e3319;border-radius:8px;color:#e7eae3; cursor:pointer; text-decoration:none; font-size:13px
+    }
+    .btn:hover{filter:brightness(1.08)}
+    .grid{display:grid;gap:10px}
+    .mapbox{
+      aspect-ratio: 16/10; background:#0d1209;border:1px dashed #2e3319;border-radius:10px; overflow:hidden;
+      display:grid; place-items:center; color:#a5ae98; text-align:center; padding:10px
+    }
+    .mapbox img{max-width:100%; height:100%; object-fit:cover}
+    .foot{
+      max-width:1200px;margin:8px auto 24px;padding:0 18px;color:#9aa38b;font-size:12px
+    }
+    code{background:#0d1209;border:1px solid #2e3319;border-radius:6px;padding:1px 6px}
+    .highlight{color:#fff; font-weight:700}
+  </style>
 </head>
 <body>
-  <div id="landing">
-    <h1>Echo Platoon Intelligence Network</h1>
-    <p class="tagline">Australian Army Cadets training simulation; no real networks accessed.</p>
-    <div id="scenario-list" class="scenarios"></div>
+  <header>
+    <div class="wrap">
+      <div class="brand">
+        <div class="badge">⚔️</div>
+        <div>
+          <div style="font-size:14px;opacity:.85">Echo Platoon</div>
+          <div style="font-size:18px;line-height:1">INTELNET – Training Terminal</div>
+        </div>
+      </div>
+    </div>
+  </header>
+
+  <main>
+    <!-- Terminal -->
+    <section class="term" aria-label="Terminal">
+      <div class="term-bar">
+        <span class="dot"></span><span class="dot yellow"></span><span class="dot green"></span>
+        <span class="term-title">/dev/ttyECHO :: simulated offline console</span>
+      </div>
+      <div id="screen" class="screen" role="log" aria-live="polite"></div>
+      <div class="term-bar" style="gap:10px">
+        <span class="prompt">echo@ops</span><span class="host">/alpha?</span><span>$</span>
+        <input id="cmd" class="cmd" type="text" autofocus spellcheck="false" autocomplete="off" placeholder="type 'help' to begin…" />
+        <span class="caret" aria-hidden="true"></span>
+      </div>
+    </section>
+
+    <!-- Side panel -->
+    <aside class="panel">
+      <h3>Mission Panel</h3>
+      <div class="body grid">
+        <div class="status">
+          <div class="k">Objective</div><div class="v">Find two 4‑digit codes</div>
+          <div class="k">Alpha node</div><div class="v" id="alphaState">Unknown</div>
+          <div class="k">Bravo node</div><div class="v" id="bravoState">Unknown</div>
+          <div class="k">Progress</div><div class="v" id="progress">0 / 2 codes</div>
+        </div>
+
+        <div>
+          <div style="margin:.5rem 0 .25rem;color:#cfd7bf;">Quick actions</div>
+          <div class="chips">
+            <button class="btn" data-run="scan">Run scan</button>
+            <button class="btn" data-run="hint">Hint</button>
+            <button class="btn" data-run="map">Show map</button>
+            <button class="btn" data-run="reset">Reset</button>
+            <button class="btn" data-run="help">Help</button>
+          </div>
+        </div>
+
+        <div>
+          <div style="margin:.5rem 0 .25rem;color:#cfd7bf;">Area map (optional)</div>
+          <div id="mapbox" class="mapbox" tabindex="0">
+            <div>
+              <div>Drop a map image here or</div>
+              <div><label class="btn" style="margin-top:8px;cursor:pointer">
+                <input id="mapfile" type="file" accept="image/*" hidden />
+                Upload image
+              </label></div>
+            </div>
+          </div>
+        </div>
+
+        <div style="font-size:12px;color:#a5ae98">
+          Tip: Use <code>decode base64 &lt;file-or-text&gt;</code> or <code>decode rot13 &lt;file-or-text&gt;</code>.  
+          Submit a code with <code>submit 1234</code>.
+        </div>
+      </div>
+    </aside>
+  </main>
+
+  <div class="foot">
+    This activity is a training simulation (offline). No real systems are accessed. Ensure supervision and age‑appropriate delivery per Defence Youth Policy.
   </div>
 
-  <div id="terminal" class="terminal hidden" role="region" aria-live="polite">
-    <div id="log"></div>
-    <div class="input-line">
-      <span class="prompt">&gt;</span>
-      <input id="cmd" autocomplete="off" aria-label="Command line" />
-      <span class="cursor blink">_</span>
-    </div>
-    <div class="controls">
-      <button id="help-btn" class="icon-btn" title="Help"><i class="fa fa-question-circle"></i></button>
-      <button id="reset-btn" class="icon-btn" title="Reset"><i class="fa fa-undo"></i></button>
-    </div>
-  </div>
+  <script>
+  ;(()=>{
 
-  <script type="module" src="js/loader.js"></script>
+    // —— Scenario data (easy to tweak) —— //
+    const GAME = {
+      codes: { alpha: "1847", bravo: "9302" },
+      found: { alpha: false, bravo: false },
+      currentHost: null,
+      nodes: {
+        alpha: {
+          name: "raven-relay (alpha)",
+          banner: "Connected to ALPHA relay. Authorised users only.",
+          files: {
+            "ops/encoded.msg": "Q09ERTogMTg0Nw==", // "CODE: 1847"
+            "ops/readme.txt": "Ops note: bandwidth caps remain in effect.\nReminder: never store codes in plain text.",
+            "docs/notice.txt": "If intercepted: all sensitive strings MUST be base64 before transit."
+          }
+        },
+        bravo: {
+          name: "raven-store (bravo)",
+          banner: "Connected to BRAVO storage node. Minimal services exposed.",
+          files: {
+            "intel/msg.enc": "FRPERG PVCURE: EBG13\nCODES: ABG VA CYNPR.\nCNFFJBEQ: \"ENIRA\".\nQRFP: 'Pbqr vf va gur frpbaq yvar'.",
+            "intel/manifest.txt": "Archive rotation weekly. Cipher hint embedded in message.",
+            "tmp/raven.dat": "Svefg ahzore: abg urer."
+          }
+        }
+      }
+    };
+
+    // —— DOM helpers —— //
+    const screen = document.getElementById('screen');
+    const input = document.getElementById('cmd');
+    const mapbox = document.getElementById('mapbox');
+    const mapfile = document.getElementById('mapfile');
+
+    const S = {
+      write(txt, cls="out"){ 
+        const row = document.createElement('div');
+        row.className = 'row ' + cls;
+        row.textContent = txt;
+        screen.appendChild(row);
+        screen.scrollTop = screen.scrollHeight;
+      },
+      prompt(){ 
+        const row = document.createElement('div');
+        row.className = 'row';
+        row.innerHTML = `<span class="prompt">echo@ops</span><span class="host">/${GAME.currentHost||''}</span><span> $</span>`;
+        screen.appendChild(row);
+        screen.scrollTop = screen.scrollHeight;
+      },
+      hr(){ S.write('────────────────────────────────────────────────', 'muted'); }
+    };
+
+    // —— Utilities —— //
+    const rot13 = (s)=> s.replace(/[a-zA-Z]/g, c=>{
+      const base = c <= 'Z' ? 65 : 97;
+      return String.fromCharCode((c.charCodeAt(0)-base+13)%26+base);
+    });
+
+    const decodeBase64 = (s)=>{
+      try{
+        // allow file-like content with line breaks
+        return atob(s.replace(/\s+/g,''));
+      }catch(e){ return null; }
+    };
+
+    const fileLookup = (path)=>{
+      if(!GAME.currentHost) return null;
+      const files = GAME.nodes[GAME.currentHost].files;
+      return files[path] ?? null;
+    };
+
+    const listFiles = ()=>{
+      if(!GAME.currentHost) { S.write("Not connected. Use: connect alpha|bravo", "warn"); return; }
+      const entries = Object.keys(GAME.nodes[GAME.currentHost].files);
+      if(!entries.length) { S.write("(no files)"); return; }
+      // pretty tree
+      const tree = {};
+      entries.forEach(p=>{
+        const [dir,file] = p.split(/\/(.+)/);
+        (tree[dir]??=(new Set())).add(file);
+      });
+      Object.entries(tree).forEach(([dir,set])=>{
+        S.write(dir + "/", "muted");
+        [...set].forEach(f=> S.write("  " + f));
+      });
+    };
+
+    const updatePanel = ()=>{
+      document.getElementById('alphaState').textContent = GAME.found.alpha ? `Code ${GAME.codes.alpha} found` : (GAME.currentHost==='alpha'?'Connected':'Unknown');
+      document.getElementById('bravoState').textContent = GAME.found.bravo ? `Code ${GAME.codes.bravo} found` : (GAME.currentHost==='bravo'?'Connected':'Unknown');
+      const total = (GAME.found.alpha?1:0) + (GAME.found.bravo?1:0);
+      document.getElementById('progress').textContent = `${total} / 2 codes`;
+    };
+
+    const victoryCheck = ()=>{
+      if(GAME.found.alpha && GAME.found.bravo){
+        S.hr();
+        S.write("MISSION COMPLETE ✅", "success");
+        S.write(`Take these to the lock box:  ${GAME.codes.alpha}  +  ${GAME.codes.bravo}`, "success");
+        S.hr();
+      }
+    };
+
+    // —— Command handlers —— //
+    const handlers = {
+      help(){
+        S.write("Available commands:", "muted");
+        S.write("  help                    Show this help");
+        S.write("  scan                    Recon for Raven nodes");
+        S.write("  connect alpha|bravo     Open a session");
+        S.write("  ls                      List files on current node");
+        S.write("  cat <path>              Print a file");
+        S.write("  decode base64 <x>       Decode Base64 of <file|text>");
+        S.write("  decode rot13  <x>       Decode ROT13 of <file|text>");
+        S.write("  status                  Show progress");
+        S.write("  submit 1234             Submit a discovered code");
+        S.write("  map                     Toggle map panel highlight");
+        S.write("  hint                    Contextual hint");
+        S.write("  clear                   Clear the screen");
+        S.write("  reset                   Reset the exercise");
+      },
+      clear(){ screen.innerHTML=''; },
+      scan(){
+        S.write("Running passive scan…", "muted");
+        setTimeout(()=>{
+          S.write("• Found host: alpha  (raven-relay)  ports: 80/tcp  2222/tcp");
+          S.write("• Found host: bravo  (raven-store)  ports: 8080/tcp minimal services");
+          S.write("Hint: try `connect alpha`", "muted");
+        }, 300);
+      },
+      connect(arg){
+        if(!arg || !GAME.nodes[arg]){ S.write("Usage: connect alpha|bravo", "warn"); return; }
+        GAME.currentHost = arg;
+        S.write("→ " + GAME.nodes[arg].banner, "host");
+        updatePanel();
+      },
+      ls(){ listFiles(); },
+      cat(path){
+        if(!path){ S.write("Usage: cat <path>", "warn"); return; }
+        const val = fileLookup(path);
+        if(val==null){ S.write("No such file here.", "err"); return; }
+        S.write("----- "+path+" -----", "muted");
+        S.write(val);
+        S.write("----- end -----", "muted");
+      },
+      decode(kind, rest){
+        if(!kind || !rest){ S.write("Usage: decode base64|rot13 <file|text>", "warn"); return; }
+        // If rest matches a file path, use file; else use the string
+        let source = fileLookup(rest);
+        if(source==null) source = rest;
+        let out = null, label = "";
+        if(kind.toLowerCase()==='base64'){
+          out = decodeBase64(source);
+          label = "Base64";
+        }else if(kind.toLowerCase()==='rot13'){
+          out = rot13(source);
+          label = "ROT13";
+        }else{
+          S.write("Unknown decoder. Use base64 or rot13", "warn");return;
+        }
+        if(out==null){ S.write(label+" decode failed.", "err"); return; }
+        S.write(`[decoded ${label}]`);
+        S.write(out, "success");
+
+        // Auto-detect a revealed code line like "CODE: 1847"
+        const m = out.match(/CODE:\s*(\d{4})/i) || out.match(/PBQR:\s*(\d{4})/i);
+        if(m){ handlers.submit(m[1]); }
+      },
+      status(){
+        updatePanel();
+        const a = GAME.found.alpha? "complete":"pending";
+        const b = GAME.found.bravo? "complete":"pending";
+        S.write(`Alpha: ${a} | Bravo: ${b}`);
+      },
+      submit(num){
+        if(!/^\d{4}$/.test(String(num||""))){ S.write("Submit requires a 4‑digit number.", "warn"); return; }
+        const s = String(num);
+        let flagged = false;
+        if(s===GAME.codes.alpha){ GAME.found.alpha = true; flagged=true; S.write("Alpha code accepted.", "success"); }
+        if(s===GAME.codes.bravo){ GAME.found.bravo = true; flagged=true; S.write("Bravo code accepted.", "success"); }
+        if(!flagged){ S.write("Code rejected.", "err"); }
+        updatePanel(); victoryCheck();
+      },
+      map(){
+        mapbox.style.outline = mapbox.style.outline ? "" : "2px solid var(--accent)";
+        if(mapbox.querySelector("img")){ S.write("Map visible in side panel."); }
+        else { S.write("Upload an area map in the side panel (optional)."); }
+      },
+      hint(){
+        if(!GAME.currentHost){
+          S.write("Try `scan` then `connect alpha`.", "muted"); return;
+        }
+        if(GAME.currentHost==='alpha' && !GAME.found.alpha){
+          S.write("ALPHA: check files under /ops. One is Base64.", "muted");
+        }else if(GAME.currentHost==='bravo' && !GAME.found.bravo){
+          S.write("BRAVO: try ROT13 on the encrypted message in /intel.", "muted");
+        }else{
+          S.write("When you’ve found both codes, `status` then take them to the box.", "muted");
+        }
+      },
+      reset(){
+        GAME.found = {alpha:false, bravo:false};
+        GAME.currentHost = null;
+        updatePanel();
+        S.write("Exercise state reset.", "warn");
+      }
+    };
+
+    // —— Input routing —— //
+    const route = (line)=>{
+      const parts = line.trim().split(/\s+/);
+      const cmd = (parts.shift()||"").toLowerCase();
+      if(!cmd){ return; }
+      if(handlers[cmd]){
+        handlers[cmd](...parts);
+      }else{
+        S.write(`Unknown command: ${cmd} (try 'help')`, "err");
+      }
+    };
+
+    input.addEventListener('keydown', (e)=>{
+      if(e.key === 'Enter'){
+        const val = input.value;
+        S.write(`$ ${val}`, "muted");
+        route(val);
+        input.value = '';
+      }
+    });
+
+    // Quick action buttons
+    document.querySelectorAll("[data-run]").forEach(btn=>{
+      btn.addEventListener('click', ()=>{ const c = btn.getAttribute('data-run'); S.write(`$ ${c}`, "muted"); route(c); });
+    });
+
+    // Map upload / drag-drop
+    const setMap = (file)=>{
+      const url = URL.createObjectURL(file);
+      mapbox.innerHTML = `<img alt="Area map" src="${url}">`;
+      S.write("Map loaded into side panel.");
+    };
+    mapfile.addEventListener('change', e=>{
+      const f = e.target.files?.[0]; if(f) setMap(f);
+    });
+    ;['dragover','drop'].forEach(ev=>{
+      mapbox.addEventListener(ev, e=>{ e.preventDefault(); if(ev==='drop'){ const f=e.dataTransfer.files?.[0]; if(f) setMap(f);} });
+    });
+
+    // —— Boot banner —— //
+    S.write("ECHO-INTELNET v1.0 · Training build", "muted");
+    S.write("Type 'help' for commands. Objective: discover TWO 4‑digit codes.");
+    S.hr();
+    updatePanel();
+  })();
+  </script>
 </body>
 </html>
+


### PR DESCRIPTION
## Summary
- overhaul index.html with inline styles, mission panel, and interactive terminal script

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5bee5a9388329a12db1cfbe87cfa6