### PR TITLE
Add hint command and deconflict sample scenario

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,12 @@ connect to real systems.
 
 ## Usage
 Open `index.html` locally or visit the GitHub Pages deployment to launch the
-training terminal. It loads `scenarios/example-basic.json` by default. Pass a
-different file with `?scenario=filename.json` to load custom scenarios. Use
-keyboard commands to explore nodes and recover codes.
+training terminal. All CSS, scripts and images are bundled so the page works
+fully offline. At boot the terminal waits in an idle state; type `run <file>`
+to load a scenario. Example files include `scenario-patrol.json`,
+`scenario-camp.json` and `scenario-border.json`. Use keyboard commands to
+explore nodes and recover codes once a scenario is active. If a scenario
+provides guidance, `hint` will cycle through available hints.
 
 ## Development
 This project is pure client-side. To test locally run a simple web server:

--- a/css/terminal.css
+++ b/css/terminal.css
@@ -21,9 +21,9 @@ body{
   margin:0;
   color:var(--ink);
   font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono","Courier New", monospace;
-  background:
-    linear-gradient(180deg, #0d1309 0%, #0a0d08 60%),
-    url('https://224armycadetunit.com/wp-content/uploads/2024/08/bg-topo-map.svg');
+    background:
+      linear-gradient(180deg, #0d1309 0%, #0a0d08 60%),
+      url('../img/bg-topo-map.svg');
   background-size: auto, 1400px;
   background-repeat: repeat;
 }

--- a/demo-terminal.html
+++ b/demo-terminal.html
@@ -40,7 +40,7 @@
     @media (max-width:980px){ main{grid-template-columns:1fr}}
     /* Terminal */
     .term{
-      background: #0b0f08 url('https://224armycadetunit.com/wp-content/uploads/2024/08/bg-topo-map.svg') center/900px auto repeat;
+      background: #0b0f08 url('img/bg-topo-map.svg') center/900px auto repeat;
       border:1px solid #2e3319;border-radius:12px; overflow:hidden;
       box-shadow:0 10px 30px rgba(0,0,0,.35);
     }

--- a/img/bg-topo-map.svg
+++ b/img/bg-topo-map.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="900" height="900" viewBox="0 0 900 900">
+  <rect width="900" height="900" fill="#0b0f08"/>
+  <path d="M0 450 C300 300 600 600 900 450" stroke="#2e3319" stroke-width="2" fill="none"/>
+  <path d="M0 600 C250 500 650 700 900 600" stroke="#2e3319" stroke-width="2" fill="none"/>
+  <path d="M0 300 C250 400 650 200 900 300" stroke="#2e3319" stroke-width="2" fill="none"/>
+  <path d="M450 0 C300 300 600 600 450 900" stroke="#2e3319" stroke-width="2" fill="none"/>
+  <path d="M600 0 C500 250 700 650 600 900" stroke="#2e3319" stroke-width="2" fill="none"/>
+  <path d="M300 0 C400 250 200 650 300 900" stroke="#2e3319" stroke-width="2" fill="none"/>
+</svg>

--- a/index.html
+++ b/index.html
@@ -26,8 +26,8 @@
     <div class="term-bar">
       <span class="dot red"></span><span class="dot amber"></span><span class="dot green"></span>
       <span class="bar-title">/dev/int/tools :: echo-int.sh console</span>
-      <button class="btn-mini" id="btnHelp" title="Help"><i class="fa fa-circle-question"></i></button>
-      <button class="btn-mini" id="btnReset" title="Reset"><i class="fa fa-rotate-right"></i></button>
+        <button class="btn-mini" id="btnHelp" title="Help" aria-label="Help">?</button>
+        <button class="btn-mini" id="btnReset" title="Reset" aria-label="Reset">↻</button>
     </div>
 
     <div id="screen" class="screen" role="log" aria-live="polite"></div>
@@ -44,7 +44,7 @@
     <h2 class="panel-head">Mission Panel</h2>
     <div class="panel-body">
       <dl class="status">
-        <dt>Objective</dt><dd>Find two 4‑digit codes</dd>
+        <dt>Objective</dt><dd id="objective">Load a scenario to begin</dd>
         <dt>Alpha node</dt><dd id="alphaState">Unknown</dd>
         <dt>Bravo node</dt><dd id="bravoState">Unknown</dd>
         <dt>Progress</dt><dd id="progress">0 / 2 codes</dd>

--- a/js/terminal.js
+++ b/js/terminal.js
@@ -15,31 +15,14 @@
 
   // —— Scenario data —— //
   var GAME = {
-    codes: { alpha: "1847", bravo: "9302" },
-    found: { alpha: false, bravo: false },
+    codes: {},
+    found: {},
     currentHost: null,
     connected: false,
     sessionEndsAt: null,
-    nodes: {
-      alpha: {
-        name: "raven-relay (alpha)",
-        banner: "Connected to ALPHA relay. Authorised users only.",
-        files: {
-          "ops/encoded.msg": "Q09ERTogMTg0Nw==", // "CODE: 1847"
-          "ops/readme.txt": "Ops note: bandwidth caps remain in effect.\nReminder: never store codes in plain text.",
-          "docs/notice.txt": "If intercepted: all sensitive strings MUST be base64 before transit."
-        }
-      },
-      bravo: {
-        name: "raven-store (bravo)",
-        banner: "Connected to BRAVO storage node. Minimal services exposed.",
-        files: {
-          "intel/msg.enc": "FRPERG PVCURE: EBG13\nCODES: ABG VA CYNPR.\nCNFFJBEQ: \"ENIRA\".\nQRFP: 'Pbqr vf va gur frpbaq yvar'.",
-          "intel/manifest.txt": "Archive rotation weekly. Cipher hint embedded in message.",
-          "tmp/raven.dat": "Svefg ahzore: abg urer."
-        }
-      }
-    }
+    nodes: {},
+    hints: {},
+    hintIndex: {}
   };
 
   // —— DOM —— //
@@ -50,6 +33,7 @@
   var bravoState = document.getElementById('bravoState');
   var progressEl = document.getElementById('progress');
   var brief = document.getElementById('brief');
+  var objectiveEl = document.getElementById('objective');
 
   // —— Helpers —— //
   function write(txt, cls){
@@ -121,6 +105,30 @@
     return (GAME.connected && GAME.sessionEndsAt) ? (GAME.sessionEndsAt - Date.now()) : 0;
   }
 
+  function resetGameState(msg){
+    stopTimer();
+    Object.keys(GAME.found).forEach(function(k){ GAME.found[k] = false; });
+    GAME.currentHost = null;
+    GAME.connected = false;
+    GAME.sessionEndsAt = null;
+    GAME.hintIndex = {};
+    setHost(); updatePanel();
+    if(msg) write(msg, 'warn');
+  }
+
+  function loadScenario(data){
+    resetGameState();
+    GAME.codes = data.codes || {};
+    GAME.nodes = data.nodes || {};
+    GAME.hints = data.hints || {};
+    GAME.hintIndex = {};
+    GAME.found = {};
+    Object.keys(GAME.codes).forEach(function(k){ GAME.found[k] = false; });
+    objectiveEl.textContent = data.objective || '';
+    write('Loaded scenario: ' + (data.title || data.id), 'success');
+    updatePanel();
+  }
+
   // —— Session management —— //
   var timerId = null;
   function startTimer(){
@@ -189,8 +197,10 @@
       write('  decode rot13  <x>       Decode ROT13 of <file|text>');
       write('  status                  Show progress and session time');
       write('  submit 1234             Submit a discovered code');
+      write('  hint                    Show a hint (if available)');
       write('  clear                   Clear the screen');
       write('  reset                   Reset the exercise');
+      write('  run <file>              Load a scenario JSON');
     },
     clear: function(){ screen.innerHTML = ''; },
     scan: function(){
@@ -275,14 +285,24 @@
       if(!hit){ write('Code rejected.', 'err'); }
       updatePanel(); victoryCheck();
     },
+    hint: function(){
+      var ctx = GAME.currentHost || 'global';
+      var list = GAME.hints[ctx] || GAME.hints.global || [];
+      if(!list.length){ write('No hints available.', 'warn'); return; }
+      var idx = GAME.hintIndex[ctx] || 0;
+      if(idx >= list.length){ write('No more hints.', 'warn'); return; }
+      write('Hint: ' + list[idx], 'muted');
+      GAME.hintIndex[ctx] = idx + 1;
+    },
     reset: function(){
-      stopTimer();
-      GAME.found.alpha = GAME.found.bravo = false;
-      GAME.currentHost = null;
-      GAME.connected = false;
-      GAME.sessionEndsAt = null;
-      setHost(); updatePanel();
-      write('Exercise state reset.', 'warn');
+      resetGameState('Exercise state reset.');
+    },
+    run: function(file){
+      if(!file){ write('Usage: run <scenario.json>', 'warn'); return; }
+      fetch('scenarios/' + file)
+        .then(function(res){ if(!res.ok) throw new Error(); return res.json(); })
+        .then(function(data){ loadScenario(data); })
+        .catch(function(){ write('Scenario load failed.', 'err'); });
     }
   };
 
@@ -314,7 +334,7 @@
   document.getElementById('btnReset').addEventListener('click', function(){ route('reset'); });
 
   // —— Boot banner —— //
-  write('ECHO-INTELNET v1.1 · Training build', 'muted');
-  write('Objective: recover the target address in the field, then connect and retrieve TWO 4‑digit codes.');
+  write('ECHO-INTELNET v1.2 · Training build', 'muted');
+  write('No scenario loaded. Staff: run <file> (e.g., run scenario-one.json)', 'muted');
   hr(); setHost(); updatePanel();
 })();

--- a/scenarios/README.md
+++ b/scenarios/README.md
@@ -3,6 +3,12 @@
 Scenarios extend the Echo Platoon Intelligence Network with training exercises.
 Files in this folder are served statically so avoid sensitive information.
 
+## Sample scenarios
+- `scenario-patrol.json` - single-node briefing (easy)
+- `scenario-camp.json` - abandoned camp with encoded printouts (medium)
+- `scenario-border.json` - multi-node frontier sweep (hard)
+- `scenario-one.json` - training example with base64 and ROT13.
+
 ## JSON schema
 A JSON scenario describes nodes, files and hints.
 

--- a/scenarios/scenario-border.json
+++ b/scenarios/scenario-border.json
@@ -1,0 +1,49 @@
+{
+  "id": "border-watch",
+  "title": "OP BORDER WATCH",
+  "objective": "Decrypt all three sensor nodes along the frontier to report activity.",
+  "codes": {
+    "relay": "5568",
+    "watch": "3142",
+    "hq": "7605"
+  },
+  "nodes": {
+    "relay": {
+      "name": "field-relay (172.16.0.5)",
+      "banner": "Temporary signal relay.",
+      "files": {
+        "msg/base64.enc": "Q29kZTogNTU2OA=="
+      }
+    },
+    "watch": {
+      "name": "overwatch-cam (172.16.0.19)",
+      "banner": "Hidden camera node.",
+      "files": {
+        "intel/rot13.msg": "Pbqr: 3142",
+        "intel/note.txt": "Camera observes ford crossing."
+      }
+    },
+    "hq": {
+      "name": "forward-hq (172.16.0.1)",
+      "banner": "Forward HQ terminal.",
+      "files": {
+        "log/cipher.txt": "Uryyb, pbqr vf 7605",
+        "log/sitrep.txt": "Hold position until relieved."
+      }
+    }
+  },
+  "hints": {
+    "global": [
+      "Sensors broadcast at 172.16.0.x addresses."
+    ],
+    "relay": [
+      "Base64 decode /msg/base64.enc."
+    ],
+    "watch": [
+      "ROT13 the message in /intel."
+    ],
+    "hq": [
+      "ROT13 the cipher in /log."
+    ]
+  }
+}

--- a/scenarios/scenario-camp.json
+++ b/scenarios/scenario-camp.json
@@ -1,0 +1,39 @@
+{
+  "id": "ghost-camp",
+  "title": "OP GHOST CAMP",
+  "objective": "Scrape codes from equipment at an abandoned camp.",
+  "codes": {
+    "router": "4821",
+    "cache": "7719"
+  },
+  "nodes": {
+    "router": {
+      "name": "camp-router (192.168.14.3)",
+      "banner": "Dusty router humming quietly.",
+      "files": {
+        "logs/printout.txt": "Found IP on paper: 192.168.14.3",
+        "logs/secure.msg": "Q29kZTogNDgyMQ=="
+      }
+    },
+    "cache": {
+      "name": "supply-cache (10.0.0.8)",
+      "banner": "Rusty lockbox awaiting input.",
+      "files": {
+        "drop/message.enc": "Pbqr: 7719",
+        "drop/map.txt": "Cache near old firepit."
+      }
+    }
+  },
+  "hints": {
+    "global": [
+      "Printouts mention 192.168.14.3 and 10.0.0.8."
+    ],
+    "router": [
+      "Base64 decode /logs/secure.msg."
+    ],
+    "cache": [
+      "ROT13 the message in /drop."
+    ]
+  }
+}
+

--- a/scenarios/scenario-one.json
+++ b/scenarios/scenario-one.json
@@ -1,6 +1,6 @@
 {
-  "id": "example-basic",
-  "title": "Example Basic Scenario",
+  "id": "obsidian-vigil",
+  "title": "OP OBSIDIAN VIGIL",
   "objective": "Find two 4-digit codes to unlock the trophy box.",
   "codes": { "alpha": "1847", "bravo": "9302" },
   "nodes": {

--- a/scenarios/scenario-patrol.json
+++ b/scenarios/scenario-patrol.json
@@ -1,0 +1,20 @@
+{
+  "id": "patrol-brief",
+  "title": "OP PATROL BRIEF",
+  "objective": "Review the briefing node and recover the single code.",
+  "codes": { "brief": "6720" },
+  "nodes": {
+    "brief": {
+      "name": "patrol-briefing",
+      "banner": "Portable terminal left by HQ.",
+      "files": {
+        "orders.txt": "Proceed to grid CF-23. Code 6720 authorises access."
+      }
+    }
+  },
+  "hints": {
+    "global": ["Use `scan` to find the node, then `connect brief`."],
+    "brief": ["Read orders.txt for the code."]
+  }
+}
+


### PR DESCRIPTION
## Summary
- track scenario hints and expose a `hint` command for trainees
- document hint usage and ensure sample scenario has a unique id

## Testing
- `node --check js/terminal.js`
- `npm test` *(fails: Could not read package.json)*
- `npm run lint` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5c7607c5c8329ac3e87de5d4c8a3f