### PR TITLE
Remove cadets references and fix submission handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Echo Platoon Intelligence Network
 
-Static training tool for the Australian Army Cadets. This site simulates an
-intelligence network for supervised exercises. It is youth-safe and does not
+Static training tool for supervised exercises. This site simulates an
+intelligence network for practice scenarios. It is youth-safe and does not
 connect to real systems.
 
 ## Usage
@@ -36,4 +36,4 @@ Create JSON or JavaScript files in `scenarios/`. See
 3. Files like `.nojekyll` ensure JSON scenario files are served.
 
 ## Licence
-MIT Licence. See [LICENSE](LICENSE).
+Apache License 2.0. See [LICENSE](LICENSE).

--- a/index.html
+++ b/index.html
@@ -67,7 +67,7 @@
 </main>
 
 <footer class="foot wrap">
-  This activity is a training simulation for the Australian Army Cadets (Australian English). No real systems are accessed.
+  This activity is a training simulation. No real systems are accessed.
 </footer>
 
   <script type="module" src="js/terminal.js"></script>

--- a/js/terminal.js
+++ b/js/terminal.js
@@ -274,8 +274,16 @@
       num = String(num || '');
       if(!/^\d{4}$/.test(num)){ write('Submit requires a 4‑digit number.', 'warn'); return; }
       var hit = false;
-      if(num===GAME.codes.alpha){ if(!GAME.found.alpha){ write('Alpha code accepted.', 'success'); } GAME.found.alpha = true; hit=true; }
-      if(num===GAME.codes.bravo){ if(!GAME.found.bravo){ write('Bravo code accepted.', 'success'); } GAME.found.bravo = true; hit=true; }
+      if(num===GAME.codes.alpha){
+        if(!GAME.found.alpha){ write('Alpha code accepted.', 'success'); }
+        GAME.found.alpha = true;
+        hit = true;
+      }
+      if(num===GAME.codes.bravo){
+        if(!GAME.found.bravo){ write('Bravo code accepted.', 'success'); }
+        GAME.found.bravo = true;
+        hit = true;
+      }
       if(!hit){ write('Code rejected.', 'err'); }
       updatePanel(); victoryCheck();
     },


### PR DESCRIPTION
## Summary
- Drop Australian Army Cadets mentions from documentation and site footer
- Align README with Apache License 2.0
- Clean up submission handler logic for clarity

## Testing
- `npx eslint js/terminal.js` *(fails: ESLint couldn't find an eslint.config file)*
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a65ea37cd883298cbe14e799e0e2a4