### PR TITLE
feat: add pluggable scenario support and examples

### DIFF
--- a/scenarios/README.md
+++ b/scenarios/README.md
@@ -1,0 +1,61 @@
+# Scenario Files
+
+Scenario files define missions for the training terminal. Place each file in this directory and load it from the terminal using the `run` or `load` commands.
+
+## JSON format
+
+A scenario expressed in JSON should follow this structure:
+
+```json
+{
+  "id": "sample-id",
+  "title": "OP SAMPLE",
+  "objective": "Find both codes.",
+  "codes": {"alpha": "1234", "bravo": "5678"},
+  "nodes": {
+    "alpha": {
+      "name": "alpha node",
+      "banner": "Connected to ALPHA node.",
+      "files": {
+        "path/to/file.txt": "File contents"
+      }
+    },
+    "bravo": {
+      "name": "bravo node",
+      "banner": "Connected to BRAVO node.",
+      "files": {
+        "path/to/file.txt": "File contents"
+      }
+    }
+  }
+}
+```
+
+## Text format
+
+Scenarios can also be written as simple `key=value` text files using dot notation for nested keys:
+
+```
+id=sample-text
+title=OP TEXT SAMPLE
+objective=Demonstrate text scenarios
+codes.alpha=1234
+codes.bravo=5678
+nodes.alpha.name=alpha node
+nodes.alpha.banner=Connected to ALPHA
+nodes.alpha.files.ops/encoded.msg=Q09ERTogMTIzNA==
+nodes.bravo.name=bravo node
+nodes.bravo.banner=Connected to BRAVO
+nodes.bravo.files.intel/msg.enc=PBQR: 5678
+```
+
+## Running
+
+From the terminal:
+
+```
+run scenario-two.json
+load scenario-four.txt
+```
+
+The terminal loads files from this directory, so only the file name is required.

--- a/scenarios/scenario-four.txt
+++ b/scenarios/scenario-four.txt
@@ -1,0 +1,12 @@
+# Simple text scenario
+id=text-demo
+title=OP TEXT DEMO
+objective=Text files can define scenarios too.
+codes.alpha=1234
+codes.bravo=5678
+nodes.alpha.name=text-alpha
+nodes.alpha.banner=Connected to TEXT ALPHA.
+nodes.alpha.files.ops/encoded.msg=Q09ERTogMTIzNA==
+nodes.bravo.name=text-bravo
+nodes.bravo.banner=Connected to TEXT BRAVO.
+nodes.bravo.files.intel/msg.enc=PBQR: 5678

--- a/scenarios/scenario-three.json
+++ b/scenarios/scenario-three.json
@@ -1,0 +1,22 @@
+{
+  "id": "silent-forest",
+  "title": "OP SILENT FOREST",
+  "objective": "Locate both recovery codes hidden in the forest nodes.",
+  "codes": { "alpha": "9012", "bravo": "3456" },
+  "nodes": {
+    "alpha": {
+      "name": "forest-relay (alpha)",
+      "banner": "Connected to ALPHA forest relay.",
+      "files": {
+        "ops/encoded.msg": "Q09ERTogOTAxMg=="
+      }
+    },
+    "bravo": {
+      "name": "forest-cache (bravo)",
+      "banner": "Connected to BRAVO forest cache.",
+      "files": {
+        "intel/msg.enc": "PBQR: 3456"
+      }
+    }
+  }
+}

--- a/scenarios/scenario-two.json
+++ b/scenarios/scenario-two.json
@@ -1,0 +1,23 @@
+{
+  "id": "crimson-snow",
+  "title": "OP CRIMSON SNOW",
+  "objective": "Recover both 4-digit launch codes.",
+  "codes": { "alpha": "3141", "bravo": "2718" },
+  "nodes": {
+    "alpha": {
+      "name": "snow-relay (alpha)",
+      "banner": "Connected to ALPHA snow relay.",
+      "files": {
+        "ops/encoded.msg": "Q09ERTogMzE0MQ==",
+        "docs/tip.txt": "Decode Base64 in /ops to proceed."
+      }
+    },
+    "bravo": {
+      "name": "snow-cache (bravo)",
+      "banner": "Connected to BRAVO cache.",
+      "files": {
+        "intel/msg.enc": "FRPERG PVCURE: EBG13\nPBQR: 2718"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- allow `run` to load JSON or key=value text scenario files and add `load` alias
- boot terminal in scenario-less state instructing operators to `run <file>`
- document scenario format and include three example scenarios

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a660c4994c83298e1f4c43c1d9e654