### PR TITLE
Add hint command and enrich scenario hints

### DIFF
--- a/js/commandHandlers.js
+++ b/js/commandHandlers.js
@@ -30,6 +30,7 @@ export function createHandlers(deps){
       write('Available commands:', 'muted');
       write('  help                    Show this help');
       write('  scan                    Passive sweep (may not reveal hidden hosts)');
+      write('  hint                    Show a hint');
       write('  connect <ip|name>  Attempt link to target');
       write('  disconnect              Terminate current session');
       write('  ls                      List files on current node');
@@ -50,6 +51,22 @@ export function createHandlers(deps){
         write('No broadcast beacons detected. Field reconnaissance may be required.', 'warn');
         write('Tip: look for a target address in recovered notes.', 'muted');
       }, 300);
+    },
+    hint(){
+      const hints = GAME.hints || {};
+      const idxMap = GAME.hintIndex || {};
+      let key = 'global';
+      if(GAME.connected && GAME.currentHost && Array.isArray(hints[GAME.currentHost])){
+        key = GAME.currentHost;
+      }
+      const list = hints[key] || [];
+      const idx = idxMap[key] || 0;
+      if(idx < list.length){
+        write('Hint: ' + list[idx], 'muted');
+        idxMap[key] = idx + 1;
+      } else {
+        write('No more hints available.', 'warn');
+      }
     },
     connect(arg){
       if(!arg){ write('Usage: connect <ip or name>', 'warn'); return; }

--- a/js/gameState.js
+++ b/js/gameState.js
@@ -18,7 +18,9 @@ export const GAME = {
   connected: false,
   sessionEndsAt: null,
   nodes: {},
-  completeMessage: null
+  completeMessage: null,
+  hints: {},
+  hintIndex: {}
 };
 
 // --- Utilities --- //

--- a/js/terminalView.js
+++ b/js/terminalView.js
@@ -155,6 +155,7 @@ function disconnectUser(){
 function resetGameState(msg){
   stopTimer();
   Object.keys(GAME.found).forEach(function(k){ GAME.found[k] = false; });
+  GAME.hintIndex = {};
   GAME.currentHost = null;
   GAME.connected = false;
   GAME.sessionEndsAt = null;
@@ -169,6 +170,9 @@ function loadScenario(data){
   GAME.codes = data.codes || {};
   GAME.nodes = data.nodes || {};
   GAME.completeMessage = data.completeMessage || null;
+  GAME.hints = data.hints || {};
+  GAME.hintIndex = {};
+  if(!Array.isArray(GAME.hints.global)) GAME.hints.global = [];
   GAME.found = {};
   objectiveEl.textContent = data.objective || '';
   Array.from(statusEl.querySelectorAll('.node-item')).forEach(function(el){ el.remove(); });

--- a/scenarios/scenario-mgrs-demo.json
+++ b/scenarios/scenario-mgrs-demo.json
@@ -32,8 +32,14 @@
     }
   },
   "hints": {
-    "global": ["Use decode base64 and decode rot13 to read encrypted files."],
-    "alpha": ["The ops file hides the first code."],
-    "bravo": ["Raven unit message conceals the second code."]
+    "global": [
+      "Some files are encoded with Base64 or ROT13; decode them and note the MGRS grids."
+    ],
+    "alpha": [
+      "Open logs/code.enc and decode Base64 for the first code and its grid."
+    ],
+    "bravo": [
+      "The raven message in /intel is ROT13 encoded and reveals the second code with its grid."
+    ]
   }
 }

--- a/scenarios/scenario-one.json
+++ b/scenarios/scenario-one.json
@@ -25,8 +25,15 @@
     }
   },
   "hints": {
-    "global": ["Use `scan`, then `connect alpha`.", "Try `decode base64` and `decode rot13`."],
-    "alpha": ["Check /ops files; one is Base64."],
-    "bravo": ["ROT13 the message in /intel."]
+    "global": [
+      "Run `scan` to find targets, then `connect alpha` to begin.",
+      "Encrypted notes use Base64 and ROT13; try `decode base64` and `decode rot13`."
+    ],
+    "alpha": [
+      "Check the /ops directory; decode `encoded.msg` with Base64 to uncover the first code."
+    ],
+    "bravo": [
+      "The file in /intel is ROT13; decode it to reveal the second code."
+    ]
   }
 }

--- a/scenarios/scenario-three.json
+++ b/scenarios/scenario-three.json
@@ -20,5 +20,17 @@
         "intel/msg.enc": "PBQR: 3456"
       }
     }
+  },
+  "hints": {
+    "global": [
+      "Explore each node for encoded messages.",
+      "One code is Base64 encoded; the other is in plain sight."
+    ],
+    "alpha": [
+      "The /ops/encoded.msg file is Base64 and hides the first code."
+    ],
+    "bravo": [
+      "Check /intel/msg.enc for the second code."
+    ]
   }
 }

--- a/scenarios/scenario-two.json
+++ b/scenarios/scenario-two.json
@@ -21,5 +21,17 @@
         "intel/msg.enc": "FRPERG PVCURE: EBG13\nPBQR: 2718"
       }
     }
+  },
+  "hints": {
+    "global": [
+      "Files may be encoded; use decode commands to read them.",
+      "Each node hides a 4-digit launch code."
+    ],
+    "alpha": [
+      "The message in /ops/encoded.msg is Base64; decode it for the first code."
+    ],
+    "bravo": [
+      "The intel message is ROT13 encoded; decoding reveals the second code."
+    ]
   }
 }


### PR DESCRIPTION
## Summary
- add `hint` command that cycles through global or node-specific hints
- track hint state in game data and reset with scenario changes
- expand demo scenarios with descriptive hints for each node

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a6773239a883298235da4071eb8f70