### PR TITLE
Fix terminal input caret position

### DIFF
--- a/css/terminal.css
+++ b/css/terminal.css
@@ -94,10 +94,9 @@ body{
 }
 .cmd{
   flex:1; background:transparent; color:var(--ink); border:0; outline:0; font:inherit;
+  caret-color: #c8ff8c;
 }
 .cmd::placeholder{color:#8aa07c}
-.caret{width:8px; height:16px; background:#c8ff8c; animation:blink 1s steps(1) infinite}
-@keyframes blink{50%{opacity:0}}
 
 /* Panel */
 .panel{

--- a/demo-terminal.html
+++ b/demo-terminal.html
@@ -65,11 +65,7 @@
     .warn{color:#ffd07a}
     .err{color:#ff9c9c}
     .inputline{display:flex; gap:8px; align-items:flex-start}
-    .caret{
-      width:8px;height:16px;background:#c8ff8c;animation:blink 1s steps(1) infinite
-    }
-    @keyframes blink{50%{opacity:0}}
-    .cmd{flex:1;background:transparent;border:0;color:#e7eae3;outline:0;font:inherit}
+    .cmd{flex:1;background:transparent;border:0;color:#e7eae3;outline:0;font:inherit;caret-color:#c8ff8c}
     .cmd::placeholder{color:#90a07e}
     /* Side panel */
     .panel{
@@ -127,7 +123,6 @@
       <div class="term-bar" style="gap:10px">
         <span class="prompt">echo@ops</span><span class="host">/alpha?</span><span>$</span>
         <input id="cmd" class="cmd" type="text" autofocus spellcheck="false" autocomplete="off" placeholder="type 'help' to begin…" />
-        <span class="caret" aria-hidden="true"></span>
       </div>
     </section>
 

--- a/index.html
+++ b/index.html
@@ -35,7 +35,6 @@
     <div class="term-input">
       <span class="prompt">echo@ops</span><span class="host" id="host">/</span><span class="dollar">$</span>
       <input id="cmd" class="cmd" type="text" autocomplete="off" spellcheck="false" placeholder="type 'help' to begin…" />
-      <span class="caret" aria-hidden="true"></span>
     </div>
   </section>
 


### PR DESCRIPTION
## Summary
- remove extra caret element and rely on input's built-in cursor
- color the input caret for better visibility
- update demo terminal accordingly

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a67f33b7088329a1906abb1fa7ee21